### PR TITLE
Make it work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-gcc -Wall -O0 -g3 -I./include src/cuckoo_filter.c tests/cuckootest.c -o test
-gcc -Wall -O0 -g3 -I./include src/cuckoo_filter.c tests/cuckootest2.c -o test2
+gcc -Wall -std=c99 -fsanitize=address -O2 -g3 -I./include src/cuckoo_filter.c tests/cuckootest.c -o test
+gcc -Wall -std=c99 -fsanitize=address -O2 -g3 -I./include src/cuckoo_filter.c tests/cuckootest2.c -o test2
 

--- a/src/cuckoo_filter.c
+++ b/src/cuckoo_filter.c
@@ -150,15 +150,14 @@ cuckoo_filter_new (
     bucket_count <<= 1;
   }
 
+  /* FIXME: Should check for integer overflows here */
   size_t allocation_in_bytes = (sizeof(cuckoo_filter_t)
     + (bucket_count * CUCKOO_NESTS_PER_BUCKET * sizeof(cuckoo_nest_t)));
 
-  if (0 != posix_memalign((void **) &new_filter, sizeof(uint64_t),
-    allocation_in_bytes)) {
+  new_filter = calloc(allocation_in_bytes, 1);
+  if (!new_filter) {
     return CUCKOO_FILTER_ALLOCATION_FAILED;
   }
-
-  memset(new_filter, 0, allocation_in_bytes);
 
   new_filter->last_victim = NULL;
   memset(&new_filter->victim, 0, sizeof(new_filter)->victim);

--- a/tests/cuckootest.c
+++ b/tests/cuckootest.c
@@ -32,6 +32,21 @@ main (int argc, char ** argv) {
   if (CUCKOO_FILTER_OK == rc) {
     printf("%s/%d: %d\n", __func__, __LINE__, rc);
   }
+
+  int i;
+  for (i = 0; i < 460000; i++) {
+    rc = cuckoo_filter_add(filter, &i, sizeof(i));
+    if (CUCKOO_FILTER_OK != rc) {
+      printf("%s/%d: %d\n", __func__, __LINE__, rc);
+    }
+  }
+
+  for (i = 0; i < 460000; i++) {
+    rc = cuckoo_filter_contains(filter, &i, sizeof(i));
+    if (CUCKOO_FILTER_OK != rc) {
+      printf("%s/%d: %d %d\n", __func__, __LINE__, rc, i);
+    }
+  }
   
   rc = cuckoo_filter_free(&filter);
   if (CUCKOO_FILTER_OK != rc) {


### PR DESCRIPTION
This filter was completely broken since 4b1d866ebc03b403a04f05377f4bda4ff9f85f51, which, while only partially fixing a very real issue, made the indexing inconsistent between add/remove and lookup.

Further, fingerprint value of 0 was allowed as such while also being a magic value used to mark empty entries. This produced occasional false negatives - something a proper Cuckoo filter must never have.

While at it, I also added usage of ASan for tests, a test at _requested_ 92% load factor (somehow even 94% often fails despite the filter is actually larger than requested, indicating there's something imperfect in the filter implementation), and switched away from misuse of `posix_memalign()` since suitability for a mere `uint64_t` is guaranteed by simple `malloc()` and `calloc()`.

The implementation is still far from optimal, and I don't recommend it for actual use, but this PR should make it another valid reference to consider.

There are two other forks that also fixed the off-by-ones and made other changes, but still had bugs preventing the filter from working reliably. I also sent PRs against those: https://github.com/mscastanho/libcuckoofilter/pull/1 https://github.com/avgerin0s/libcuckoofilter/pull/1